### PR TITLE
Adding fill_missing function draft and test cases

### DIFF
--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -1,4 +1,9 @@
-def fill_missing(df, column_dict, num_trans, cat_trans):
+import numpy as np
+import pandas as pd
+
+## TODO: Categorical features which are strings? ["A", "B", "C"]....isnull does not seem to be working? 
+
+def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
     """
     Fill missing values in the dataframe based on user input.
 
@@ -8,12 +13,12 @@ def fill_missing(df, column_dict, num_trans, cat_trans):
         A pandas dataframe
     column_dict: dictionary
         A dictionary with keys = 'numeric','categorical','text', 
-	and values = a list of columns that fall into
-	each respective category.
+        and values = a list of columns that fall into
+        each respective category.
     num_trans -- string
-        imputation method for numeric features
+        imputation method for numeric features, options are "mean", "median"
     cat_trans -- list
-        imputation method for categorical features
+        imputation method for categorical features, options are "mode"
 
     Returns
     -------
@@ -21,4 +26,64 @@ def fill_missing(df, column_dict, num_trans, cat_trans):
         A pandas dataframe
     
     """
-    return 5
+    
+    # TODO
+    # Missing assert on column keys are "numeric" and "categorical"
+    
+    # Check input types are as specified
+    assert isinstance(train_df, pd.DataFrame), "train_df must be a Pandas DF"
+    assert isinstance(test_df, pd.DataFrame), "test_df must be a Pandas DF"
+    assert isinstance(column_dict, dict), "column_dict must be a dictionary"
+    assert isinstance(num_trans, str), "num_trans should be a string"
+    assert isinstance(cat_trans, str), "cat_trans should be a string"
+    
+    # Check train set and test set columns are the same
+    assert np.array_equal(train_df.columns, test_df.columns), "train_df and test_df must have the same columns"
+    
+    # Check all the columns listed in dictionary are in the df
+    for keys, values in column_dict.items():
+        for column in values:
+            assert column in train_df.columns, "columns in dictionary must be in dataframe"
+            
+    # Check that numerical imputation method is one of the two options 
+    assert num_trans == "mean" or num_trans == "median", \
+        "numerical imputation method can only be mean or median"
+    
+    # Check that categorical imputation method is the only option
+    assert cat_trans == "mode"
+    
+    # Imputation methods for numerical transforms
+    for column in column_dict['numeric']:
+        # get column mean or median
+        if num_trans == "mean":
+            col_imp = train_df[column].mean()
+        if num_trans == "median":
+            col_imp = train_df[column].median()
+            
+        # Get index of NaN values in train columns
+        # Todo: If these are empty (no Nan) is that fine
+        index_train = train_df[column].index[train_df[column].apply(np.isnan)]
+        index_test = test_df[column].index[test_df[column].apply(np.isnan)]
+        
+        # Use impute value on train set
+        train_df.loc[index_train,column] = col_imp
+        # Use same impute value on test set
+        test_df.loc[index_test,column] = col_imp
+            
+    
+    # Imputation methods for categorical transforms 
+    for column in column_dict['categorical']:
+       # Note:  If mode is a tie, pandas picks lower value pick the lower value!
+        col_imp = train_df[column].mode()[0]
+        
+        # Get index of NaN values in train columns
+        index_train = train_df[column].index[train_df[column].isnull()]
+        index_test = test_df[column].index[test_df[column].isnull()]
+        
+        # Use impute value on train set
+        train_df.loc[index_train,column] = col_imp
+        # Use same impute value on test set
+        test_df.loc[index_test,column] = col_imp
+        
+        
+    return (train_df, test_df)

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -9,10 +9,12 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
 
     Arguments
     ---------     
-    df : pandas.core.frame.DataFrame
-        A pandas dataframe
+    train_df : pandas.core.frame.DataFrame
+        The training set, will be used for calculating and inputing values
+    test_df: pandas.core.frame.DataFrame
+        The test set, will be used for inputing values only.
     column_dict: dictionary
-        A dictionary with keys = 'numeric','categorical','text', 
+        A dictionary with keys = 'numeric','categorical',
         and values = a list of columns that fall into
         each respective category.
     num_trans -- string
@@ -26,10 +28,7 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
         A pandas dataframe
     
     """
-    
-    # TODO
-    # Missing assert on column keys are "numeric" and "categorical"
-    
+        
     # Check input types are as specified
     assert isinstance(train_df, pd.DataFrame), "train_df must be a Pandas DF"
     assert isinstance(test_df, pd.DataFrame), "test_df must be a Pandas DF"
@@ -39,6 +38,11 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
     
     # Check train set and test set columns are the same
     assert np.array_equal(train_df.columns, test_df.columns), "train_df and test_df must have the same columns"
+    
+    # Check dictionary keys are numeric and categorical
+    for key in column_dict.keys():
+        assert key == 'numeric' or key == 'categorical', \
+        "column_dict keys can be only 'numeric' and 'categorical'"
     
     # Check all the columns listed in dictionary are in the df
     for keys, values in column_dict.items():

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -9,7 +9,7 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
 
     Arguments
     ---------     
-    train_df : pandas.core.frame.DataFrame
+    X_train: pandas.core.frame.DataFrame
         The training set, will be used for calculating and inputing values
     test_df: pandas.core.frame.DataFrame
         The test set, will be used for inputing values only.

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -17,7 +17,7 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
         A dictionary with keys = 'numeric','categorical',
         and values = a list of columns that fall into
         each respective category.
-    num_trans -- string
+    num_trans -- string(default -"mean")
         imputation method for numeric features, options are "mean", "median"
     cat_trans -- list
         imputation method for categorical features, options are "mode"

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -11,7 +11,7 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
     ---------     
     X_train: pandas.core.frame.DataFrame
         The training set, will be used for calculating and inputing values
-    test_df: pandas.core.frame.DataFrame
+    X_test: pandas.core.frame.DataFrame
         The test set, will be used for inputing values only.
     column_dict: dictionary
         A dictionary with keys = 'numeric','categorical',

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -56,6 +56,10 @@ def fill_missing(X_train, X_test, column_dict, num_imp, cat_imp):
     
     # Check that categorical imputation method is the only option
     assert cat_imp == "mode", "cat_imp can only take 'mode' as argument value"
+
+    # Check all columns contain numeric columns
+    assert X_train.select_dtypes(include=["float", 'int']).shape[1] == X_train.shape[1], \
+        "column values must be all numeric, must encode categorical variables as integers"
     
     # Imputation methods for numerical transforms
     for column in column_dict['numeric']:

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -54,7 +54,7 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
         "numerical imputation method can only be mean or median"
     
     # Check that categorical imputation method is the only option
-    assert cat_trans == "mode"
+    assert cat_trans == "mode", "cat_trans can only take 'mode' as argument value"
     
     # Imputation methods for numerical transforms
     for column in column_dict['numeric']:

--- a/pylaundry/fill_missing.py
+++ b/pylaundry/fill_missing.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 ## TODO: Categorical features which are strings? ["A", "B", "C"]....isnull does not seem to be working? 
 
-def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
+def fill_missing(X_train, X_test, column_dict, num_imp, cat_imp):
     """
     Fill missing values in the dataframe based on user input.
 
@@ -17,27 +17,28 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
         A dictionary with keys = 'numeric','categorical',
         and values = a list of columns that fall into
         each respective category.
-    num_trans -- string(default -"mean")
+    num_imp -- string(default -"mean")
         imputation method for numeric features, options are "mean", "median"
-    cat_trans -- list
+    cat_imp -- list
         imputation method for categorical features, options are "mode"
 
     Returns
     -------
-    df_imputed-- pandas.core.frame.DataFrame  
-        A pandas dataframe
+    dictionary 
+        A dictionary with keys "X_train" and "X_test",
+        and the modified dataframes as values.
     
     """
         
     # Check input types are as specified
-    assert isinstance(train_df, pd.DataFrame), "train_df must be a Pandas DF"
-    assert isinstance(test_df, pd.DataFrame), "test_df must be a Pandas DF"
+    assert isinstance(X_train, pd.DataFrame), "X_train must be a Pandas DF"
+    assert isinstance(X_test, pd.DataFrame), "X_test must be a Pandas DF"
     assert isinstance(column_dict, dict), "column_dict must be a dictionary"
-    assert isinstance(num_trans, str), "num_trans should be a string"
-    assert isinstance(cat_trans, str), "cat_trans should be a string"
+    assert isinstance(num_imp, str), "num_imp should be a string"
+    assert isinstance(cat_imp, str), "cat_imp should be a string"
     
     # Check train set and test set columns are the same
-    assert np.array_equal(train_df.columns, test_df.columns), "train_df and test_df must have the same columns"
+    assert np.array_equal(X_train.columns, X_test.columns), "X_train and X_test must have the same columns"
     
     # Check dictionary keys are numeric and categorical
     for key in column_dict.keys():
@@ -47,47 +48,47 @@ def fill_missing(train_df, test_df, column_dict, num_trans, cat_trans):
     # Check all the columns listed in dictionary are in the df
     for keys, values in column_dict.items():
         for column in values:
-            assert column in train_df.columns, "columns in dictionary must be in dataframe"
+            assert column in X_train.columns, "columns in dictionary must be in dataframe"
             
     # Check that numerical imputation method is one of the two options 
-    assert num_trans == "mean" or num_trans == "median", \
+    assert num_imp == "mean" or num_imp == "median", \
         "numerical imputation method can only be mean or median"
     
     # Check that categorical imputation method is the only option
-    assert cat_trans == "mode", "cat_trans can only take 'mode' as argument value"
+    assert cat_imp == "mode", "cat_imp can only take 'mode' as argument value"
     
     # Imputation methods for numerical transforms
     for column in column_dict['numeric']:
         # get column mean or median
-        if num_trans == "mean":
-            col_imp = train_df[column].mean()
-        if num_trans == "median":
-            col_imp = train_df[column].median()
+        if num_imp == "mean":
+            col_imp = X_train[column].mean()
+        if num_imp == "median":
+            col_imp = X_train[column].median()
             
         # Get index of NaN values in train columns
         # Todo: If these are empty (no Nan) is that fine
-        index_train = train_df[column].index[train_df[column].apply(np.isnan)]
-        index_test = test_df[column].index[test_df[column].apply(np.isnan)]
+        index_train = X_train[column].index[X_train[column].apply(np.isnan)]
+        index_test = X_test[column].index[X_test[column].apply(np.isnan)]
         
         # Use impute value on train set
-        train_df.loc[index_train,column] = col_imp
+        X_train.loc[index_train,column] = col_imp
         # Use same impute value on test set
-        test_df.loc[index_test,column] = col_imp
+        X_test.loc[index_test,column] = col_imp
             
     
     # Imputation methods for categorical transforms 
     for column in column_dict['categorical']:
        # Note:  If mode is a tie, pandas picks lower value pick the lower value!
-        col_imp = train_df[column].mode()[0]
+        col_imp = X_train[column].mode()[0]
         
         # Get index of NaN values in train columns
-        index_train = train_df[column].index[train_df[column].isnull()]
-        index_test = test_df[column].index[test_df[column].isnull()]
+        index_train = X_train[column].index[X_train[column].isnull()]
+        index_test = X_test[column].index[X_test[column].isnull()]
         
         # Use impute value on train set
-        train_df.loc[index_train,column] = col_imp
+        X_train.loc[index_train,column] = col_imp
         # Use same impute value on test set
-        test_df.loc[index_test,column] = col_imp
+        X_test.loc[index_test,column] = col_imp
         
         
-    return (train_df, test_df)
+    return {"X_train": X_train, "X_test": X_test}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "MIT"
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]
+pytest-cov = "^2.8.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/test_fill_missing.py
+++ b/tests/test_fill_missing.py
@@ -23,22 +23,22 @@ def generate_test_set():
 
 # I know not using the fixtures is gross but it was giving me assertion errors when I did...
 def test_output_type():
-    output = fill_missing(train_df = pd.DataFrame({
+    output = fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,2,1,1,1], 
                                     'num1':[1,2,3,4,5,6,7,None],
                                     'num2':[10,10,10,10,10,10,10,None],
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0],
                                 'num2':[None,None,0.0,1.0,98.0]
                             }), 
                           column_dict = {'numeric': ['num1', 'num2'],
                                           'categorical': ['cat1']},
-                          num_trans = "mean",
-                          cat_trans = "mode")
-    train_output = output[0]
-    test_output = output[1]
+                          num_imp = "mean",
+                          cat_imp = "mode")
+    train_output = output['X_train']
+    test_output = output['X_test']
     # Check length and type of output
     assert len(output) == 2, \
         "Output of fill_missing() should be two dataframes"
@@ -50,20 +50,20 @@ def test_output_type():
 
 # Simple test of mean inputation function
 def test_mean_num():
-    output = fill_missing(train_df = pd.DataFrame({
+    output = fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "mean",
-                          cat_trans = "mode")
-    train_output = output[0]
-    test_output = output[1]
+                          num_imp = "mean",
+                          cat_imp = "mode")
+    train_output = output['X_train']
+    test_output = output['X_test']
     
     # Mean column 1 is 3 for inputed value 
     # Check for same inputation train and test
@@ -74,20 +74,20 @@ def test_mean_num():
 
 # Simple test of median inputation function
 def test_median_num():
-    output = fill_missing(train_df = pd.DataFrame({
+    output = fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mode")
-    train_output = output[0]
-    test_output = output[1]
+                          num_imp = "median",
+                          cat_imp = "mode")
+    train_output = output['X_train']
+    test_output = output['X_test']
     
     # Mean column 1 is 3 for inputed value 
     # Check for same inputation train and test
@@ -98,20 +98,20 @@ def test_median_num():
 
 # Simple test of mode inputation function
 def test_mode_cat():
-    output = fill_missing(train_df = pd.DataFrame({
+    output = fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mode")
-    train_output = output[0]
-    test_output = output[1]
+                          num_imp = "median",
+                          cat_imp = "mode")
+    train_output = output['X_train']
+    test_output = output['X_test']
     
     # Mean column 1 is 3 for inputed value 
     # Check for same inputation train and test
@@ -124,15 +124,15 @@ def test_mode_cat():
 # Non pandas train set
 def test_bad_train_set():
     try: 
-        fill_missing(train_df = np.array(1),
-                          test_df = pd.DataFrame({
+        fill_missing(X_train = np.array(1),
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mode")
+                          num_imp = "median",
+                          cat_imp = "mode")
         
     except AssertionError:
         pass 
@@ -140,15 +140,15 @@ def test_bad_train_set():
 # Non pandas DF test set
 def test_bad_test_set():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }),
-                          test_df = np.array(1), 
+                          X_test = np.array(1), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mode")
+                          num_imp = "median",
+                          cat_imp = "mode")
         
     except AssertionError:
         pass 
@@ -156,17 +156,17 @@ def test_bad_test_set():
 # Non dictionary for columns
 def test_bad_col_dict():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = ["cat1", "num1"],
-                          num_trans = "median",
-                          cat_trans = "mode")
+                          num_imp = "median",
+                          cat_imp = "mode")
         
     except AssertionError:
         pass 
@@ -174,18 +174,18 @@ def test_bad_col_dict():
 # Not mean or median for num imputation
 def test_non_accepted_num():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "mode",
-                          cat_trans = "mode")
+                          num_imp = "mode",
+                          cat_imp = "mode")
         
     except AssertionError:
         pass 
@@ -193,18 +193,18 @@ def test_non_accepted_num():
 # Non mode cat imputation
 def test_non_accepted_cat():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mean")
+                          num_imp = "median",
+                          cat_imp = "mean")
         
     except AssertionError:
         pass 
@@ -213,18 +213,18 @@ def test_non_accepted_cat():
 # Different column names in train and test set
 def test_diff_columns():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num2':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           column_dict = {'numeric': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mean")
+                          num_imp = "median",
+                          cat_imp = "mean")
         
     except AssertionError:
         pass
@@ -232,19 +232,19 @@ def test_diff_columns():
 # Columns in col_dict which aren't in df
 def test_bad_columns():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           # insert column which is not in the df
                           column_dict = {'numeric': ['num2'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mean")
+                          num_imp = "median",
+                          cat_imp = "mean")
         
     except AssertionError:
         pass
@@ -252,19 +252,19 @@ def test_bad_columns():
 # column key which is not one of two specified names
 def test_bad_dict_keys():
     try: 
-        fill_missing(train_df = pd.DataFrame({
+        fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
                                     'num1':[1.5,2.5,3.5,None,4.5]
                           }), 
-                          test_df = pd.DataFrame({
+                          X_test = pd.DataFrame({
                                 'cat1':[1,None,3,1,3], 
                                 'num1':[1.5,2.5,None,2.0,2.0]
                             }), 
                           # insert wrong column key
                           column_dict = {'numerical': ['num1'],
                                           'categorical': ['cat1']},
-                          num_trans = "median",
-                          cat_trans = "mean")
+                          num_imp = "median",
+                          cat_imp = "mean")
         
     except AssertionError:
         pass 

--- a/tests/test_fill_missing.py
+++ b/tests/test_fill_missing.py
@@ -136,3 +136,135 @@ def test_bad_train_set():
         
     except AssertionError:
         pass 
+
+# Non pandas DF test set
+def test_bad_test_set():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }),
+                          test_df = np.array(1), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mode")
+        
+    except AssertionError:
+        pass 
+
+# Non dictionary for columns
+def test_bad_col_dict():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = ["cat1", "num1"],
+                          num_trans = "median",
+                          cat_trans = "mode")
+        
+    except AssertionError:
+        pass 
+
+# Not mean or median for num imputation
+def test_non_accepted_num():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "mode",
+                          cat_trans = "mode")
+        
+    except AssertionError:
+        pass 
+
+# Non mode cat imputation
+def test_non_accepted_cat():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mean")
+        
+    except AssertionError:
+        pass 
+
+    
+# Different column names in train and test set
+def test_diff_columns():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num2':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mean")
+        
+    except AssertionError:
+        pass
+    
+# Columns in col_dict which aren't in df
+def test_bad_columns():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          # insert column which is not in the df
+                          column_dict = {'numeric': ['num2'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mean")
+        
+    except AssertionError:
+        pass
+
+# column key which is not one of two specified names
+def test_bad_dict_keys():
+    try: 
+        fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          # insert wrong column key
+                          column_dict = {'numerical': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mean")
+        
+    except AssertionError:
+        pass 

--- a/tests/test_fill_missing.py
+++ b/tests/test_fill_missing.py
@@ -1,11 +1,138 @@
 import pytest
 import pandas as pd
+import numpy as np
 from pylaundry.fill_missing import fill_missing
 
-# Sample input
-x = [1, 1]
-df = pd.DataFrame([[1, 2, None, 3], [3, 2, 4, 5], [4, 1,  5, 6], [2, None, 4, 3]])
-threshold = 0.9
+@pytest.fixture
+def generate_train_set():
+    df = pd.DataFrame({
+        'cat1':[1,2,None,1,2,1,1,1], 
+        'num1':[1,2,3,4,5,6,7,None],
+        'num2':[10,10,10,10,10,10,10,None],
+    })
+    return df
 
-def test_mean_imputation():
-    assert (fill_missing(df, dict(), "mean", "mode") == 5)
+@pytest.fixture
+def generate_test_set():
+    df = pd.DataFrame({
+        'cat1':[1,None,3,1,3], 
+        'num1':[1.5,2.5,None,2.0,2.0],
+        'num2':[None,None,0.0,1.0,98.0]
+    })
+    return df
+
+# I know not using the fixtures is gross but it was giving me assertion errors when I did...
+def test_output_type():
+    output = fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,2,1,1,1], 
+                                    'num1':[1,2,3,4,5,6,7,None],
+                                    'num2':[10,10,10,10,10,10,10,None],
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0],
+                                'num2':[None,None,0.0,1.0,98.0]
+                            }), 
+                          column_dict = {'numeric': ['num1', 'num2'],
+                                          'categorical': ['cat1']},
+                          num_trans = "mean",
+                          cat_trans = "mode")
+    train_output = output[0]
+    test_output = output[1]
+    # Check length and type of output
+    assert len(output) == 2, \
+        "Output of fill_missing() should be two dataframes"
+    assert isinstance(train_output, pd.DataFrame), \
+        "Training df should be a Pandas DF"
+    assert isinstance(test_output, pd.DataFrame), \
+        "Test df should be a Pandas DF"
+
+
+# Simple test of mean inputation function
+def test_mean_num():
+    output = fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "mean",
+                          cat_trans = "mode")
+    train_output = output[0]
+    test_output = output[1]
+    
+    # Mean column 1 is 3 for inputed value 
+    # Check for same inputation train and test
+    assert train_output["num1"][3] == 3, \
+        "Inputed mean value should be 3.0 in train set"
+    assert test_output["num1"][2] == 3, \
+        "Inputed mean value should be 3.0 in test set"
+
+# Simple test of median inputation function
+def test_median_num():
+    output = fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mode")
+    train_output = output[0]
+    test_output = output[1]
+    
+    # Mean column 1 is 3 for inputed value 
+    # Check for same inputation train and test
+    assert train_output["num1"][3] == 3, \
+        "Inputed median value should be 3.0 in train set"
+    assert test_output["num1"][2] == 3, \
+        "Inputed median value should be 3.0 in test set"
+
+# Simple test of mode inputation function
+def test_mode_cat():
+    output = fill_missing(train_df = pd.DataFrame({
+                                    'cat1':[1,2,None,1,1], 
+                                    'num1':[1.5,2.5,3.5,None,4.5]
+                          }), 
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mode")
+    train_output = output[0]
+    test_output = output[1]
+    
+    # Mean column 1 is 3 for inputed value 
+    # Check for same inputation train and test
+    assert train_output["cat1"][2] == 1, \
+        "Inputed mode value should be 1 in train set"
+    assert test_output["cat1"][1] == 1, \
+        "Inputed mode value should be 1 in test set"
+
+# Test for bad inputs
+# Non pandas train set
+def test_bad_train_set():
+    try: 
+        fill_missing(train_df = np.array(1),
+                          test_df = pd.DataFrame({
+                                'cat1':[1,None,3,1,3], 
+                                'num1':[1.5,2.5,None,2.0,2.0]
+                            }), 
+                          column_dict = {'numeric': ['num1'],
+                                          'categorical': ['cat1']},
+                          num_trans = "median",
+                          cat_trans = "mode")
+        
+    except AssertionError:
+        pass 

--- a/tests/test_fill_missing.py
+++ b/tests/test_fill_missing.py
@@ -3,38 +3,28 @@ import pandas as pd
 import numpy as np
 from pylaundry.fill_missing import fill_missing
 
-@pytest.fixture
-def generate_train_set():
-    df = pd.DataFrame({
-        'cat1':[1,2,None,1,2,1,1,1], 
-        'num1':[1,2,3,4,5,6,7,None],
-        'num2':[10,10,10,10,10,10,10,None],
-    })
-    return df
+# Define basic objects to be used in test suite function
+X_train = pd.DataFrame({
+            'cat1':[1,2,None,1,1], 
+            'num1':[1.5,2.5,3.5,None,4.5],
+})
 
-@pytest.fixture
-def generate_test_set():
-    df = pd.DataFrame({
-        'cat1':[1,None,3,1,3], 
-        'num1':[1.5,2.5,None,2.0,2.0],
-        'num2':[None,None,0.0,1.0,98.0]
-    })
-    return df
+X_test =  pd.DataFrame({
+            'cat1':[1,None,3,1,3], 
+            'num1':[1.5,2.5,None,2.0,2.0]
+})
 
-# I know not using the fixtures is gross but it was giving me assertion errors when I did...
+col_dict = {'numeric': ['num1'],
+            'categorical': ['cat1']}
+                          
+"""
+Test the output is the correct length, and that the
+training and testing dataframes output are of the correct type
+"""
 def test_output_type():
-    output = fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,2,1,1,1], 
-                                    'num1':[1,2,3,4,5,6,7,None],
-                                    'num2':[10,10,10,10,10,10,10,None],
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0],
-                                'num2':[None,None,0.0,1.0,98.0]
-                            }), 
-                          column_dict = {'numeric': ['num1', 'num2'],
-                                          'categorical': ['cat1']},
+    output = fill_missing(X_train, 
+                          X_test, 
+                          col_dict,
                           num_imp = "mean",
                           cat_imp = "mode")
     train_output = output['X_train']
@@ -48,18 +38,13 @@ def test_output_type():
         "Test df should be a Pandas DF"
 
 
-# Simple test of mean inputation function
+"""
+Testing accuracy of mean imputation function
+"""
 def test_mean_num():
-    output = fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,1], 
-                                    'num1':[1.5,2.5,3.5,None,4.5]
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0]
-                            }), 
-                          column_dict = {'numeric': ['num1'],
-                                          'categorical': ['cat1']},
+    output = fill_missing(X_train, 
+                          X_test, 
+                          col_dict,
                           num_imp = "mean",
                           cat_imp = "mode")
     train_output = output['X_train']
@@ -72,7 +57,9 @@ def test_mean_num():
     assert test_output["num1"][2] == 3, \
         "Inputed mean value should be 3.0 in test set"
 
-# Simple test of median inputation function
+"""
+Testing accuracy of median imputation function
+"""
 def test_median_num():
     output = fill_missing(X_train = pd.DataFrame({
                                     'cat1':[1,2,None,1,1], 
@@ -96,18 +83,13 @@ def test_median_num():
     assert test_output["num1"][2] == 3, \
         "Inputed median value should be 3.0 in test set"
 
-# Simple test of mode inputation function
+"""
+Testing accuracy of mode imputation function
+"""
 def test_mode_cat():
-    output = fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,1], 
-                                    'num1':[1.5,2.5,3.5,None,4.5]
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0]
-                            }), 
-                          column_dict = {'numeric': ['num1'],
-                                          'categorical': ['cat1']},
+    output = fill_missing(X_train, 
+                          X_test, 
+                          col_dict,
                           num_imp = "median",
                           cat_imp = "mode")
     train_output = output['X_train']
@@ -120,8 +102,10 @@ def test_mode_cat():
     assert test_output["cat1"][1] == 1, \
         "Inputed mode value should be 1 in test set"
 
-# Test for bad inputs
-# Non pandas train set
+"""
+Testing for errors thrown with bad inputs
+Non pandas dataframe X_train
+"""
 def test_bad_train_set():
     try: 
         fill_missing(X_train = np.array(1),
@@ -137,7 +121,10 @@ def test_bad_train_set():
     except AssertionError:
         pass 
 
-# Non pandas DF test set
+"""
+Testing for errors thrown with bad inputs
+Non pandas dataframe X_test
+"""
 def test_bad_test_set():
     try: 
         fill_missing(X_train = pd.DataFrame({
@@ -153,25 +140,25 @@ def test_bad_test_set():
     except AssertionError:
         pass 
 
-# Non dictionary for columns
+"""
+Testing for errors thrown with bad inputs
+Non dictionary for column assignments
+"""
 def test_bad_col_dict():
     try: 
-        fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,1], 
-                                    'num1':[1.5,2.5,3.5,None,4.5]
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0]
-                            }), 
-                          column_dict = ["cat1", "num1"],
-                          num_imp = "median",
-                          cat_imp = "mode")
+        fill_missing(X_train, 
+                    X_test , 
+                    column_dict = ["cat1", "num1"],
+                    num_imp = "median",
+                    cat_imp = "mode")
         
     except AssertionError:
         pass 
 
-# Not mean or median for num imputation
+"""
+Testing for errors thrown with bad inputs
+Not mean or median for numerical imputation
+"""
 def test_non_accepted_num():
     try: 
         fill_missing(X_train = pd.DataFrame({
@@ -190,27 +177,26 @@ def test_non_accepted_num():
     except AssertionError:
         pass 
 
-# Non mode cat imputation
+"""
+Testing for errors thrown with bad inputs
+Not mode for categorical imputation
+"""
 def test_non_accepted_cat():
     try: 
-        fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,1], 
-                                    'num1':[1.5,2.5,3.5,None,4.5]
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0]
-                            }), 
-                          column_dict = {'numeric': ['num1'],
-                                          'categorical': ['cat1']},
-                          num_imp = "median",
-                          cat_imp = "mean")
+        fill_missing(X_train, 
+                    X_test, 
+                    col_dict,
+                    num_imp = "median",
+                    cat_imp = "mean")
         
     except AssertionError:
         pass 
 
     
-# Different column names in train and test set
+"""
+Testing for errors thrown with bad inputs
+Different col names in X_train and X_test
+"""
 def test_diff_columns():
     try: 
         fill_missing(X_train = pd.DataFrame({
@@ -229,7 +215,10 @@ def test_diff_columns():
     except AssertionError:
         pass
     
-# Columns in col_dict which aren't in df
+"""
+Testing for errors thrown with bad inputs
+Column names which are not in the DF's
+"""
 def test_bad_columns():
     try: 
         fill_missing(X_train = pd.DataFrame({
@@ -248,23 +237,38 @@ def test_bad_columns():
         
     except AssertionError:
         pass
-
-# column key which is not one of two specified names
+"""
+Testing for errors thrown with bad inputs
+Column key which is not one of two specified names
+""" 
 def test_bad_dict_keys():
     try: 
-        fill_missing(X_train = pd.DataFrame({
-                                    'cat1':[1,2,None,1,1], 
-                                    'num1':[1.5,2.5,3.5,None,4.5]
-                          }), 
-                          X_test = pd.DataFrame({
-                                'cat1':[1,None,3,1,3], 
-                                'num1':[1.5,2.5,None,2.0,2.0]
-                            }), 
-                          # insert wrong column key
-                          column_dict = {'numerical': ['num1'],
-                                          'categorical': ['cat1']},
-                          num_imp = "median",
-                          cat_imp = "mean")
+        fill_missing(X_train, 
+                    X_test, 
+                    # insert wrong column key
+                    column_dict = {'numerical': ['num1'],
+                                   'categorical': ['cat1']},
+                    num_imp = "median",
+                    cat_imp = "mean")
         
     except AssertionError:
         pass 
+
+"""
+Testing for errors thrown with bad inputs
+Columns which contain non-numeric values
+""" 
+def test_non_numeric_columns():
+    try: 
+        fill_missing(X_train = pd.DataFrame({
+                        'cat1':['a','b',None,'c','a'], 
+                        'num1':[1.5,2.5,3.5,None,4.5]
+                    }), 
+                    X_test = X_test, 
+                    column_dict = {'numeric': ['num1'],
+                                   'categorical': ['cat1']},
+                    num_imp = "median",
+                    cat_imp = "mean")
+        
+    except AssertionError:
+        pass


### PR DESCRIPTION
**First draft of fill_missing function, it has:**

- mean imputation for numerical columns
- median imputation for numerical columns
- mode imputation for categorical cols
Note:
categorical columns can only be read in as integers, not characters!

**First draft of fill_missing tests:**
- testing for correctness of output in simple cases
- testing for throwing errors at the right time.
- currently passes 12/12 tests, but many more need to be added to be robust.
- Tests give 100% branch and line coverage

- **Test cases are very ugly, @fixtures were not working (would throw error), so had to continue re-specifying the data. Need to fix this for readability.**